### PR TITLE
DMG: Page restructure

### DIFF
--- a/consoles/gameboy.md
+++ b/consoles/gameboy.md
@@ -8,104 +8,92 @@ logo: logos/GameBoy.png
 photo: consoles/GameBoy.jpg
 model: DMG
 ---
-Later nicknamed “DMG” after its product code “Dot Matrix Game”. The original “grey brick” was released in 1989. In 1995 the “Play It Loud” series released. The PI" series only added new shell colours and was not full a hardware revision. PIL consoles use "chip on board" package components and thus the PCBs are covered in epoxy blobs.
+Later nicknamed “DMG” after its product code “Dot Matrix Game”. The original “grey brick” was released in 1989. In 1995 the “Play It Loud” series released. The PIL series only added new shell colours and was not full a hardware revision. PIL consoles use "chip on board" package components and thus the PCBs are covered in epoxy blobs.
 
 Table of Contents:
 <!--ts-->
-* [**Original Game Boy Problems**](--original-game-boy-problems--)
-  * [Dead Vertical Lines on DMG](--dead-vertical-lines-on-dmg--)
-  * [Screen Rot](--screen-rot--)
-  * [Vertical lines in the LCD](--vertical-lines-in-the-lcd--)
-  * [Horizontal lines in the LCD](--horizontal-lines-in-the-lcd--)
-  * [Splotchy circles in LCD (after backlight/bivert install)](--splocthy-circles-in-lcd--)
-* [**Original Game Boy Mods**](--original-game-boy-mods--)
+* [**Mods**](#mods)
+	* [**Screen Mods**](#screen-mods)
+		* [**Replacement Screen Kits**](#replacement-screen-kits)
+		* [**OEM Screen Backlight Mods**](#oem-screen-backlight-mods)
+	* [**Other Mods**](#other-mods) 
+* [**Problems**](#problems)
+	* [Screen Rot](#screen-rot)
+	* [Vertical lines in the LCD](#vertical-lines-in-the-lcd)
+	* [Horizontal lines in the LCD](#horizontal-lines-in-the-lcd)
+	* [Splotchy circles in LCD (after backlight/bivert install)](#splotchy-circles-in-lcd-after-backlightbivert-install)
 <!--te-->
 
 Last Content Revision: 2020-12-16
-
-## **Original Game Boy Problems**
-
-Don't forget that [the common problems section](index) also has more info, such as failure to power on or speaker issues. 
- 
-* [Dead Vertical Lines on DMG](http://www.instructables.com/id/Game-Boy-DMG-Vertical-Line-Repair/)
- 
-* Screen Rot
- 
-  * What is it? With the classic Game Boy, screen rot can occur just about anywhere on the LCD. Sometimes it’s just a few small specs of black right in the middle of the LCD, sometimes it’s a whole corner of the LCD filled with black splotches. It is NOT mold or water damage, despite what some people will tell you.
-  * How do I fix it? Unfortunately, there’s no known repair for this other than to just replace the entire LCD board. Unless you have legendary soldering skills, removing the LCD from the board will be quite difficult. 
- 
-* Vertical lines in the LCD
- 
-  * What are they? This is a VERY common problem with DMGs. These show up as missing vertical lines on the LCD. Sometimes if you press on the rubber strip below the LCD, you can get the lines to disappear for a short period of time.
-  * How do I fix it? Fortunately, this problem is generally pretty easy to fix. See [here](https://www.youtube.com/watch?v=l4PArFarm_) or [here](http://www.instructables.com/id/Game-Boy-DMG-Vertical-Line-Repair/). One thing worth noting is that you should continue with the iron until you can briefly run the iron across the entire bottom of the LCD and the lines don’t show up anymore. You can get the lines to disappear but until you make sure they stop showing up with heat applied, it won’t be a long-lasting repair. 500° F / 260° C is an adequate amount of heat to use.
- 
-* Horizontal lines in the LCD
- 
-  * What are they? Not nearly as common a problem as vertical lines, but they do still show up every now and then. The problem is similar to vertical lines, but instead the lines show up horizontally across the screen.
-  * How do I fix it? You will have to lift the LCD from its plastic bezel to gain access to the horizontal ribbon cable. This is a much more difficult fix than the vertical lines fix, but it can be done.
- 
-      * Remove the 2 screws holding down the vertical ribbon cable.
-      * Carefully pry the LCD free from the plastic bezel using a plastic implement of some sort.
-      * Prop up the LCD so you can access the horizontal ribbon cable with a soldering iron. The area of interest looks much like the area on the vertical cable underneath the rubber strip.
-      * Gently run the iron back and forth across this area until the lines disappear. 500° F / 260° C is an adequate amount of heat to use.
-
-* Splotchy circles in LCD (after backlight/bivert install)
- 
-  * What are they? Circles under the LCD that looks like trapped liquid. See [this image for an example.](https://i.redd.it/wsvc4e42n7u41.jpg) This phenomenon is called "Newtonian Rings" and is common in these circumstances. 
-  * How do I fix it? The fix will involve either completely separating the glass LCD from the plastic polarizer layer (air gap) or completely joining them together (adhesive polarizer). See this video from /u/esotericsean for [a method of air gapping the polarizer.](https://www.youtube.com/watch?v=-6_s_kNVT0o) If you want to join the polarizer to the LCD OEM style, you'll need a polarizer with pre-applied adhesive. Air gapping is the preferred method. This also applied to Game Boy Pocket. 
   
-  
-## **Original Game Boy Mods**
+# Mods
+
+## Screen Mods
 
 Looking for a backlight mod? Why not check out [this guide](../wiki/backlightmods#dmg) from /u/Admiral_Butter_Crust on all the different backlight kits for DMG. 
 
-* Backlight install (parts: [Regular kit from HandHeldLegend](https://handheldlegend.com/collections/dmg/products/game-boy-backlight-dmg-and-pocket) or [Retromodding](https://www.retromodding.com/collections/gameboy-pocket/products/game-boy-backlight?variant=12258355576855) or [EL Kit from Kitsh-Bent](https://store.kitsch-bent.com/product/el_dmg)) – [Instructables guide](http://www.instructables.com/id/Game-Boy-Backlight-DIY/)/[Video guide](https://www.youtube.com/watch?v=93iCzWmSK4Q)  
-    * A note on potential issues -- Check the problems section above for more info on "Newtonian Rings."
-
-* Replacement 3" screen (stock is 2.4", parts from [BennVenn](https://bennvenn.myshopify.com/collections/aftermarket-lcds/products/dmg-3-backlit-lcd-kit)) - [Image Guide](https://bennvenn.myshopify.com/pages/dmg-lcd-install-guide)
+### Replacement Screen Kits
 
 * One Chip / HiVision Replacement transflective LCD kit (AIO kit, much smaller than stock, found on [aliexpress](https://www.aliexpress.com/item/4000408551332.html)) - Found a guide you like? Let me (u/Admiral_Butter_Crust) know and I'll add it, otherwise, see the images on the seller's page
-
-* BennVenn Replacement transflective LCD kit (**Freckleshack v2.5 - Aioli** parts from [BennVenn](https://bennvenn.myshopify.com/collections/aftermarket-lcds/products/freckleshack-pre-orders-batch-7?variant=29881069535335)) – Kits not yet shipped but install should be similar to AIO kit above due to the reduced PCB size and addition of touch sensor for brightness control
-
-* Replacement stock sized kit (from BennVenn) - [coming soon](https://www.facebook.com/BennVennElectronics/posts/2482250121888426)
-
 * "Moon IPS" Replacement LCD kit (from [taobao](https://2.taobao.com/item.htm?id=617735730270)) - [Youtube](https://www.youtube.com/watch?v=zqmTNd748lU)
-
 * Funnyplaying Replacement IPS LCD kit (from [Funnyplaying](https://funnyplaying.com/collections/product/products/dmg-retro-pixel-ips-lcd-kit)) - [Image Guide](https://funnyplaying.com/blogs/gameboy-advance-news/dng-retro-pixel-ips-lcd-kit-install-tutorial) or [video](https://www.youtube.com/watch?v=vCXkbPcrYeQ)
-
 * One Chip Replacement IPS LCD kit (sold by [RGRS](https://retrogamerepairshop.com/products/pre-order-only-game-boy-dmg-01-backlight-ips-lcd-screen-mod-kit-v3-rips) and other vendors on ebay/aliexpress) - [Image Guide](https://cdn.discordapp.com/attachments/246604458744610816/668546575563489320/image0.jpg) and [Video Guide](https://www.youtube.com/watch?v=_DqzA0DJ3bQ)
-    * v1 kits have a color palette bug and will need a secondary mod as well. See this [imagur album](https://imgur.com/a/DDlowE5) or [video](https://www.youtube.com/watch?v=cFpnUGuXtbY) for more info. Issue is corrected in v2.
-    * v2 kits are reported to have faulty dpad inputs when installed in some shells with some buttons. Issue is corrected in v3
-    * v3 is the currently shipping version and is identified by the BLACK PCB and "RIPS V3" markings on the PCB. The LCD is slightly different and such is not compatible with brackets designed for V1 or V2. 
-	
+	* v1 kits have a color palette bug and will need a secondary mod as well. See this [imagur album](https://imgur.com/a/DDlowE5) or [video](https://www.youtube.com/watch?v=cFpnUGuXtbY) for more info. Issue is corrected in v2.
+	* v2 kits are reported to have faulty dpad inputs when installed in some shells with some buttons. Issue is corrected in v3
+	* v3 is the currently shipping version and is identified by the BLACK PCB and "RIPS V3" markings on the PCB. The LCD is slightly different and such is not compatible with brackets designed for V1 or V2. 
 * One Chip OSD Q5 IPS Kit ("RIPS v4", from [RGRS](https://retrogamerepairshop.com/products/dmg-game-boy-dmg-rips-osd-backlight-mod-kit)) - [Youtube](https://youtu.be/_qVffKBdELI)
+* Replacement stock sized kit (from BennVenn) - [coming soon](https://www.facebook.com/BennVennElectronics/posts/2482250121888426)
+* BennVenn Replacement transflective LCD kit (**Freckleshack v2.5 - Aioli** parts from [BennVenn](https://bennvenn.myshopify.com/collections/aftermarket-lcds/products/freckleshack-pre-orders-batch-7?variant=29881069535335)) – Kits not yet shipped but install should be similar to AIO kit above due to the reduced PCB size and addition of touch sensor for brightness control
+* Replacement 3" screen (stock is 2.4", parts from [BennVenn](https://bennvenn.myshopify.com/collections/aftermarket-lcds/products/dmg-3-backlit-lcd-kit)) - [Image Guide](https://bennvenn.myshopify.com/pages/dmg-lcd-install-guide)
 
+### OEM Screen Backlight Mods
+
+* Backlight install (parts: [Regular kit from HandHeldLegend](https://handheldlegend.com/collections/dmg/products/game-boy-backlight-dmg-and-pocket) or [Retromodding](https://www.retromodding.com/collections/gameboy-pocket/products/game-boy-backlight?variant=12258355576855) or [EL Kit from Kitsh-Bent](https://store.kitsch-bent.com/product/el_dmg)) – [Instructables guide](http://www.instructables.com/id/Game-Boy-Backlight-DIY/)/[Video guide](https://www.youtube.com/watch?v=93iCzWmSK4Q)  
+    * A note on potential issues -- Check the problems section above for more info on "Newtonian Rings."
 * Bivert module install (parts: [HandHeldLegend](https://handheldlegend.com/collections/dmg/products/game-boy-bivert-biversion-module)) – [Video Guide](https://www.youtube.com/watch?v=xS8NQ3dds2k)  
-
 * Bivert mini module install (parts: [Retromodding](https://www.retromodding.com/collections/gameboy/products/game-boy-bivert-board) – Install is largely the same as above module
-
 * Bivert bare chip install (Cheaper generic chips - check ebay or aliexpress) – [Instructables guide](http://www.instructables.com/id/Game-Boy-BivertBiversion-Moditication/)  
-
 * Soft latching bivert install (Switch biversion off and on) – [Step by step guide](http://imgur.com/a/LEo8U)  
-
-* RGB backlight DIP switch install – [Credit to the_8bit_kingdom](http://imgur.com/a/lA0lw)  
-
-* How to change housing/shell – [Video Guide](https://www.youtube.com/watch?v=nfSkP6pejR0)  
-
+* RGB backlight DIP switch install – [Credit to the_8bit_kingdom](http://imgur.com/a/lA0lw)
 * RGB colour changing backlight – [Documented project](https://imgur.com/a/dUaim#0DwYjRw)  
 
+## Other Mods
+
+* How to change housing/shell – [Video Guide](https://www.youtube.com/watch?v=nfSkP6pejR0)  
 * Prosound mod (parts: [Retromodding](https://www.retromodding.com/collections/gameboy/products/gameboy-pcb-mount-pro-sound-v3) or [Kitsch-Bent](https://store.kitsch-bent.com/product/prosound-kits)) – [Simple to follow tutorial](https://web.archive.org/web/20210308122142/https://guides.brit.co/guides/mod-your-dmg-gameboy-with-prosound-stereo-jack)/[Video Guide](https://www.youtube.com/watch?v=FGlY0quuHGw)  
-
 * USB rechargeable batteries – [Step by step guide](http://imgur.com/a/uIpq4)  
-
 * Speed up or slow down DMG (under/overclocking) – [Written blog post](http://gieskes.nl/underclocking_or_overclocking_the_gameboy_classic_tutorial/), careful though as the mod is prone to freezing!  
-
 * Backlit buttons and case LEDs – [Purchasable Kit](http://store.thursdaycustoms.com/product/rgb-buttons)/[Written Guide](http://chipmusic.org/forums/topic/4152/dmg-case-leds/)  
-
 * Power LED change (can use colour changing RGBs!) – [Brief description of how it's done](http://chipmusic.org/forums/topic/6719/replacing-a-dmg-power-led-can-it-be-done/), it's easy to do this one!  
-
 * VGA Out (nobble's [DMG Consolizer](https://gamebox.systems/products/dmg-consolizer-gameboy-classic-mini-console)) - kits shipping and guides coming soon
-
 * Super Game Boy CPU Swap - [Info on the mod and tutorial](http://noizeinabox.blogspot.com/2012/06/game-boy-super-game-boy-cpu-transplant.html)
-    * Do note that PIL series DMGs have [glob-top COB](https://en.wikipedia.org/wiki/Chip_on_board) packaged CPUs and are not capable of this mod. 
+    * Do note that PIL series DMGs have [glob-top COB](https://en.wikipedia.org/wiki/Chip_on_board) packaged CPUs and are not capable of this mod.
+
+# Problems
+
+Don't forget that [the common problems section](index) also has more info, such as failure to power on or speaker issues. 
+ 
+## Screen Rot
+ 
+* What is it? With the classic Game Boy, screen rot can occur just about anywhere on the LCD. Sometimes it’s just a few small specs of black right in the middle of the LCD, sometimes it’s a whole corner of the LCD filled with black splotches. It is NOT mold or water damage, despite what some people will tell you.
+* How do I fix it? Unfortunately, there’s no known repair for this other than to just replace the entire LCD board. Unless you have legendary soldering skills, removing the LCD from the board will be quite difficult. 
+ 
+## Vertical lines in the LCD
+ 
+ * What are they? This is a VERY common problem with DMGs. These show up as missing vertical lines on the LCD. Sometimes if you press on the rubber strip below the LCD, you can get the lines to disappear for a short period of time.
+ * How do I fix it? Fortunately, this problem is generally pretty easy to fix. See [here](https://www.youtube.com/watch?v=l4PArFarm_) or [here](http://www.instructables.com/id/Game-Boy-DMG-Vertical-Line-Repair/). One thing worth noting is that you should continue with the iron until you can briefly run the iron across the entire bottom of the LCD and the lines don’t show up anymore. You can get the lines to disappear but until you make sure they stop showing up with heat applied, it won’t be a long-lasting repair. 500° F / 260° C is an adequate amount of heat to use.
+ 
+## Horizontal lines in the LCD
+ 
+* What are they? Not nearly as common a problem as vertical lines, but they do still show up every now and then. The problem is similar to vertical lines, but instead the lines show up horizontally across the screen.
+* How do I fix it? You will have to lift the LCD from its plastic bezel to gain access to the horizontal ribbon cable. This is a much more difficult fix than the vertical lines fix, but it can be done.
+ 
+	* Remove the 2 screws holding down the vertical ribbon cable.
+	* Carefully pry the LCD free from the plastic bezel using a plastic implement of some sort.
+	* Prop up the LCD so you can access the horizontal ribbon cable with a soldering iron. The area of interest looks much like the area on the vertical cable underneath the rubber strip.
+	* Gently run the iron back and forth across this area until the lines disappear. 500° F / 260° C is an adequate amount of heat to use.
+
+## Splotchy circles in LCD (after backlight/bivert install)
+
+* What are they? Circles under the LCD that looks like trapped liquid. See [this image for an example.](https://i.redd.it/wsvc4e42n7u41.jpg) This phenomenon is called "Newtonian Rings" and is common in these circumstances. 
+* How do I fix it? The fix will involve either completely separating the glass LCD from the plastic polarizer layer (air gap) or completely joining them together (adhesive polarizer). See this video from /u/esotericsean for [a method of air gapping the polarizer.](https://www.youtube.com/watch?v=-6_s_kNVT0o) If you want to join the polarizer to the LCD OEM style, you'll need a polarizer with pre-applied adhesive. Air gapping is the preferred method. This also applied to Game Boy Pocket. 


### PR DESCRIPTION
Update DMG page to fit new structure a little better (some liberties taken - backlight mods were split in two as DMG has a decent chunk of OEM screen backlighting options)

This preserves the DMG page's existing Table of Contents format, where we link to each subsection (also noting that the links work as intended now) - drop a comment if you'd prefer just keeping the top-level section links as with the MGB/CGB pages.